### PR TITLE
Remove Serena references and use autoMemoryEnabled setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Decisions use an ADR-inspired template: **Decision > Context > Options Considere
 
 | Setting | Value | Purpose |
 |---------|-------|---------|
-| `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | `1` | Disables built-in memory in favor of the continuous learning system |
+| `autoMemoryEnabled` | `false` | Disables built-in memory in favor of the continuous learning system |
 
 ---
 
@@ -171,7 +171,7 @@ mcs doctor
 mcs-continuous-learning/
 ├── techpack.yaml                       # Manifest — defines all components
 ├── config/
-│   └── settings.json                   # Disables built-in auto-memory
+│   └── settings.json                   # Disables built-in auto-memory (autoMemoryEnabled)
 ├── hooks/
 │   ├── ollama-status.sh                # Ollama health + memory re-indexing
 │   └── continuous-learning-activator.sh # Knowledge extraction reminder
@@ -192,7 +192,7 @@ mcs-continuous-learning/
 
 | Pack | Description |
 |------|-------------|
-| [mcs-core-pack](https://github.com/bguidolim/mcs-core-pack) | Foundational settings, plugins, git workflows, and Serena code navigation |
+| [mcs-core-pack](https://github.com/bguidolim/mcs-core-pack) | Foundational settings, plugins, and git workflows |
 | [mcs-ios-pack](https://github.com/bguidolim/mcs-ios-pack) | Xcode integration, simulator management, and Apple documentation |
 
 ---

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,5 +1,3 @@
 {
-  "env": {
-    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1"
-  }
+  "autoMemoryEnabled": false
 }

--- a/techpack.yaml
+++ b/techpack.yaml
@@ -133,7 +133,7 @@ components:
   # ── Configuration ───────────────────────────────────────────────────────
   - id: settings
     displayName: Settings
-    description: Disables auto-memory in favor of continuous learning system
+    description: Disables built-in auto-memory in favor of continuous learning system
     isRequired: true
     settingsFile: config/settings.json
 


### PR DESCRIPTION
## Summary
- Replaced `CLAUDE_CODE_DISABLE_AUTO_MEMORY` env var with the official `autoMemoryEnabled: false` settings key (per Claude Code v2.1.59+ docs)
- Removed Serena mention from the mcs-core-pack cross-reference in README
- Updated settings descriptions in techpack.yaml and README directory tree

## Test plan
- [ ] Run `mcs sync` on a project using this pack and verify `settings.json` applies correctly
- [ ] Start a Claude Code session and check `/memory` shows auto memory disabled
- [ ] Grep for `serena`, `UV`, and `DISABLE_AUTO_MEMORY` — no matches expected