### PR TITLE
Add memory-audit skill and staleness prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ The system captures two categories of knowledge:
 
 **Learnings** — non-obvious discoveries from debugging and investigation:
 ```
-.claude/memories/learning_swiftui_task_cancellation_on_view_dismiss.md
-.claude/memories/learning_core_data_batch_insert_memory_spike.md
-.claude/memories/learning_xcode_preview_crash_missing_environment.md
+.claude/memories/learning_background_task_watchdog_timeout.md
+.claude/memories/learning_orm_batch_insert_memory_spike.md
+.claude/memories/learning_ci_cache_invalidation_on_dependency_update.md
 ```
 
 Each learning follows a structured template: **Problem > Trigger Conditions > Solution > Verification > Example > Notes > References**.
@@ -110,6 +110,7 @@ Decisions use an ADR-inspired template: **Decision > Context > Options Considere
 | Skill | Description |
 |-------|-------------|
 | **continuous-learning** | Extracts learnings and decisions from sessions into structured memory files |
+| **memory-audit** | Reviews and audits memories to keep the knowledge base lean and valuable |
 
 ### Session Hooks
 
@@ -171,10 +172,12 @@ memory/
 │   ├── sync-memories.sh                # Ollama health + memory indexing/reindexing
 │   └── continuous-learning-activator.sh # Knowledge extraction reminder
 ├── skills/
-│   └── continuous-learning/
-│       ├── SKILL.md                    # Extraction rules and workflow
-│       └── references/
-│           └── templates.md            # Learning + Decision memory templates
+│   ├── continuous-learning/
+│   │   ├── SKILL.md                    # Extraction rules and workflow
+│   │   └── references/
+│   │       └── templates.md            # Learning + Decision memory templates
+│   └── memory-audit/
+│       └── SKILL.md                    # Audit workflow with KEEP/DROP/UPDATE verdicts
 └── templates/
     └── continuous-learning.md          # "Search KB before any task"
 ```

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ This pack implements a **closed-loop knowledge system** that captures valuable i
         |                    ^                                          |
         |                    |            .claude/memories/             |
         |                    |     ┌──────────────────────────────┐     |
-        |                    |     │  learning_swiftui_...        │     |
+        |                    |     │  learning_background_task_... │     |
         |                    |     │  decision_arch_...           │     |
-        |                    +-----│  learning_coredata_...       │<----+
+        |                    +-----│  learning_orm_batch_...      │<----+
         |                          │  decision_testing_...        │
         |                          └──────────────────────────────┘
         |                                        ^

--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -95,7 +95,7 @@ Research should **enrich** project-specific knowledge, not replace it. The goal 
 
 ### Step 4: Structure and Save
 
-Read [references/templates.md](references/templates.md) for template structures and staleness rules, then apply the appropriate template.
+Read [references/templates.md](references/templates.md) for template structures and staleness rules. For learnings, use the Learning Memory Template. For decisions, use the ADR-Inspired Template for complex trade-offs or the Simplified Template for straightforward preferences.
 
 **Save:**
 ```

--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -3,6 +3,8 @@ name: continuous-learning
 description: >
   Extracts reusable knowledge (debugging discoveries, architectural decisions, conventions)
   from work sessions and saves them as structured memory files in .claude/memories/.
+  Also use when the user asks to "run a retrospective", "extract learnings", or
+  "save what we learned" from the current session.
 allowed-tools: Write, Read, Glob, Edit, Bash, WebSearch, mcp__docs-mcp-server__search_docs, mcp__docs-mcp-server__list_libraries, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
 ---
 
@@ -10,7 +12,7 @@ allowed-tools: Write, Read, Glob, Edit, Bash, WebSearch, mcp__docs-mcp-server__s
 
 Extract reusable knowledge from work sessions and save it as memory files in `<project>/.claude/memories/`.
 
-> **Note:** `<project>` refers to the current working directory (project root) throughout this document.
+> **Note:** `<project>` refers to the current working directory (project root) throughout this document. When calling `search_docs`, the library name is the root directory name of the project (e.g., for `/Users/me/dev/my-app`, use `library: "my-app"`).
 
 ## Memory Categories
 
@@ -24,7 +26,7 @@ Knowledge discovered through debugging, investigation, or problem-solving that w
 - Discovered a workaround for a tool/framework limitation
 - Found a workflow optimization through experimentation
 
-**Examples:** `learning_swiftui_task_cancellation_on_view_dismiss`, `learning_core_data_batch_insert_memory_spike`, `learning_xcode_preview_crash_missing_environment`
+**Examples:** `learning_background_task_watchdog_timeout`, `learning_orm_batch_insert_memory_spike`, `learning_ci_cache_invalidation_on_dependency_update`
 
 ### Decisions (`decision_<domain>_<topic>`)
 
@@ -43,12 +45,12 @@ Deliberate choices about how the project should work.
 |--------|----------|
 | `architecture` | `decision_architecture_mvvm_coordinators` |
 | `codestyle` | `decision_codestyle_naming_conventions` |
-| `tooling` | `decision_tooling_swiftlint_config` |
+| `tooling` | `decision_tooling_linter_config` |
 | `testing` | `decision_testing_snapshot_strategy` |
 | `networking` | `decision_networking_retry_policy` |
 | `ui` | `decision_ui_design_system` |
-| `data` | `decision_data_core_data_vs_swiftdata` |
-| `project` | `decision_project_minimum_ios_version` |
+| `data` | `decision_data_orm_selection` |
+| `project` | `decision_project_minimum_platform_version` |
 
 ---
 
@@ -72,7 +74,7 @@ If NO to all → skip. If YES to any → continue.
 mcp__docs-mcp-server__search_docs(library: "<project>", query: "<topic>")
 ```
 
-**Fall back to file listing** if search_docs returns no results:
+**Fall back to file listing** if search_docs returns no results or the project library is not yet indexed:
 
 ```
 Glob(pattern: ".claude/memories/*.md")
@@ -82,20 +84,18 @@ Determine if: update an existing memory, cross-reference related memories, or kn
 
 ### Step 3: Research (When Appropriate)
 
-**For general topics** — use Claude Code's built-in web search:
+**For general topics** — search available documentation sources first (the user may have MCP servers providing official docs for frameworks or libraries), then fall back to web search:
 ```
 WebSearch(query: "<topic> best practices <current year>")
 ```
+
+Research should **enrich** project-specific knowledge, not replace it. The goal is to add context or verify a finding — not to save generic knowledge that any LLM already knows. If the research result is general programming advice without a project-specific angle, skip saving it.
 
 **Skip research for:** project-specific conventions, personal preferences, time-sensitive captures.
 
 ### Step 4: Structure and Save
 
-Read [references/templates.md](references/templates.md) for the full template structures.
-
-**For learnings:** Use the Learning Memory Template (Problem → Trigger Conditions → Solution → Verification → Example → Notes → References).
-
-**For decisions:** Use the ADR-Inspired Template for complex trade-offs, or the Simplified Template for straightforward preferences.
+Read [references/templates.md](references/templates.md) for template structures and staleness rules, then apply the appropriate template.
 
 **Save:**
 ```
@@ -120,16 +120,23 @@ Before saving any memory, verify:
 - [ ] No sensitive information (credentials, internal URLs)
 - [ ] Does not duplicate existing memories
 - [ ] References included if external sources were consulted
+- [ ] No brittle references that rot quickly (see Staleness Prevention below)
+
+---
+
+## Staleness Prevention
+
+Before saving, check memory content against the Staleness Rules in [references/templates.md](references/templates.md). In short: use symbol names instead of line numbers, module-level references instead of deep file paths, and omit transient details like feature flags being removed or in-progress PR numbers.
 
 ---
 
 ## Retrospective Mode
 
-When `/retrospective` is invoked:
+When the user asks to "run a retrospective", "extract learnings from this session", or similar:
 
 1. Review conversation history for extractable knowledge
-2. Search existing memories via `search_docs` (fall back to `Glob(".claude/memories/*.md")` if unavailable)
-3. List candidates with brief justifications
+2. Search existing memories following Step 2 of the Extraction Workflow
+3. List candidates with brief justifications — prioritize by the evaluation criteria in Step 1 (non-obvious investigation, architectural choices, expressed preferences)
 4. Extract top 1-3 highest-value memories
 5. Report what was created and why
 

--- a/skills/continuous-learning/references/templates.md
+++ b/skills/continuous-learning/references/templates.md
@@ -3,6 +3,18 @@
 Reference file for the continuous-learning skill. Load this when creating or updating memories
 to use the appropriate template structure.
 
+## Staleness Rules
+
+These apply to **all** templates below:
+
+- **No line numbers.** Reference symbols (types, functions, methods) instead — they survive refactors.
+- **Prefer module-level paths** over deep file paths. Use full paths only for stable, well-known files.
+- **Use semantic anchors** — method signatures, protocol names, and architectural concepts are durable.
+- **Omit transient details** — feature flags being removed, in-progress PR numbers, temporary workarounds.
+
+**Good:** `SessionManager.refreshToken(forceExpiry:)` in the `Auth` module
+**Bad:** `SessionManager.swift:142` at `Sources/Features/Auth/Session/SessionManager.swift`
+
 ---
 
 ## Learning Memory Template
@@ -28,6 +40,53 @@ to use the appropriate template structure.
 
 ## References
 [Links to documentation, articles, resources]
+```
+
+### Filled Example
+
+```markdown
+# Learning: Background task completion handler must be called before suspension
+
+## Problem
+App crashes with `0x8badf00d` (watchdog timeout) when a background network request finishes but the completion handler from `beginBackgroundTask` is never called.
+
+## Trigger Conditions
+- A network request is kicked off inside `beginBackgroundTask(expirationHandler:)`
+- The request completes successfully, but `endBackgroundTask(_:)` is not called on every code path
+- Crash appears only when the app is backgrounded during the request — never reproducible in foreground
+
+## Solution
+Ensure `endBackgroundTask(_:)` is called on **every** exit path — success, failure, and the expiration handler itself. Use a `defer` block or a single cleanup function to guarantee it.
+
+## Verification
+- Background the app during an active network request — no watchdog crash after 30 seconds
+- Check Console logs for `"Background task still running"` messages — should not appear
+
+## Example
+```swift
+var taskID = UIBackgroundTaskIdentifier.invalid
+taskID = UIApplication.shared.beginBackgroundTask {
+    // Expiration handler — last chance to clean up
+    UIApplication.shared.endBackgroundTask(taskID)
+    taskID = .invalid
+}
+
+performRequest { result in
+    defer {
+        UIApplication.shared.endBackgroundTask(taskID)
+        taskID = .invalid
+    }
+    // handle result...
+}
+```
+
+## Notes
+- The `0x8badf00d` code is Apple's "ate bad food" watchdog termination — always indicates a timeout
+- `beginBackgroundTask` gives ~30 seconds on iOS; the exact duration is not guaranteed
+- Multiple background tasks can be active simultaneously — each needs its own identifier and cleanup
+
+## References
+- https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtask
 ```
 
 ---
@@ -63,6 +122,57 @@ Use for architectural decisions, tool choices, or patterns with meaningful trade
 [Related documentation, discussions, or resources]
 ```
 
+### Filled Example
+
+```markdown
+# Decision: Repository pattern for data access layer
+
+## Decision
+All data access (network, local storage, cache) goes through Repository types that expose Combine publishers or async methods — view models never call API clients or databases directly.
+
+## Context
+As the app grew, view models were calling network clients, Core Data contexts, and cache layers directly. This made testing difficult and created implicit coupling between UI logic and data sources.
+
+## Options Considered
+- **Option A**: Direct access from view models — simple but untestable and tightly coupled
+- **Option B**: Service layer — adds an intermediary but doesn't solve the data source abstraction
+- **Option C**: Repository pattern — abstracts data source behind a protocol, composable and testable
+
+## Choice
+Option C. Repositories own the decision of where data comes from (network vs cache vs local). View models depend on repository protocols, making them easy to test with mock implementations.
+
+## Consequences
+- Every new data source requires a repository protocol + implementation
+- View models become simpler and fully testable with mock repositories
+- Caching strategy is encapsulated — can change without touching UI code
+
+## Scope
+All modules. New features must define a repository protocol in the API layer and a concrete implementation in the feature layer.
+
+## Examples
+```swift
+// Protocol in Interface
+protocol UserRepositoryType {
+    func user(id: String) -> AnyPublisher<User, Error>
+}
+
+// Implementation in Stories
+struct UserRepository: UserRepositoryType {
+    let apiClient: APIClientType
+    let cache: CacheType
+
+    func user(id: String) -> AnyPublisher<User, Error> {
+        cache.get(key: id)
+            .catch { _ in apiClient.fetchUser(id: id) }
+            .eraseToAnyPublisher()
+    }
+}
+```
+
+## References
+- Martin Fowler's Repository pattern: https://martinfowler.com/eaaCatalog/repository.html
+```
+
 ---
 
 ## Simplified Decision Template
@@ -78,4 +188,34 @@ Use for straightforward preferences without complex trade-offs.
 
 ## Examples
 [How to apply it]
+```
+
+### Filled Example
+
+```markdown
+# Decision: Use `async let` over `TaskGroup` for fixed-count parallel work
+
+## Decision
+When running a known, small number of concurrent operations (2-4), prefer `async let` bindings over `TaskGroup`.
+
+## Rationale
+- `async let` reads more naturally and avoids the boilerplate of creating a group, adding tasks, and collecting results
+- Type safety is preserved without casting from `group.next()`
+- `TaskGroup` is the right choice when the number of tasks is dynamic or large
+
+## Examples
+```swift
+// Preferred: fixed concurrency with async let
+async let profile = fetchProfile(id)
+async let settings = fetchSettings(id)
+let (p, s) = await (profile, settings)
+
+// Use TaskGroup when count is dynamic
+await withTaskGroup(of: Item.self) { group in
+    for id in ids {
+        group.addTask { await fetchItem(id) }
+    }
+    // ...
+}
+```
 ```

--- a/skills/continuous-learning/references/templates.md
+++ b/skills/continuous-learning/references/templates.md
@@ -20,6 +20,8 @@ These apply to **all** templates below:
 ## Learning Memory Template
 
 ```markdown
+# Learning: [concise title]
+
 ## Problem
 [Clear description of the problem]
 
@@ -44,7 +46,7 @@ These apply to **all** templates below:
 
 ### Filled Example
 
-```markdown
+````markdown
 # Learning: Background task completion handler must be called before suspension
 
 ## Problem
@@ -87,7 +89,7 @@ performRequest { result in
 
 ## References
 - https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtask
-```
+````
 
 ---
 
@@ -96,6 +98,8 @@ performRequest { result in
 Use for architectural decisions, tool choices, or patterns with meaningful trade-offs.
 
 ```markdown
+# Decision: [concise title]
+
 ## Decision
 [One-sentence summary of what was decided]
 
@@ -124,7 +128,7 @@ Use for architectural decisions, tool choices, or patterns with meaningful trade
 
 ### Filled Example
 
-```markdown
+````markdown
 # Decision: Repository pattern for data access layer
 
 ## Decision
@@ -171,7 +175,7 @@ struct UserRepository: UserRepositoryType {
 
 ## References
 - Martin Fowler's Repository pattern: https://martinfowler.com/eaaCatalog/repository.html
-```
+````
 
 ---
 
@@ -180,6 +184,8 @@ struct UserRepository: UserRepositoryType {
 Use for straightforward preferences without complex trade-offs.
 
 ```markdown
+# Decision: [concise title]
+
 ## Decision
 [What was decided]
 
@@ -192,7 +198,7 @@ Use for straightforward preferences without complex trade-offs.
 
 ### Filled Example
 
-```markdown
+````markdown
 # Decision: Use `async let` over `TaskGroup` for fixed-count parallel work
 
 ## Decision
@@ -218,4 +224,4 @@ await withTaskGroup(of: Item.self) { group in
     // ...
 }
 ```
-```
+````

--- a/skills/memory-audit/SKILL.md
+++ b/skills/memory-audit/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: memory-audit
+description: >
+  Review and audit memory files in .claude/memories/ to keep the knowledge base lean and valuable.
+  Use this skill when the user says "audit memories", "review memories", "clean up memories",
+  "memory audit", "check my memories", or wants to prune, deduplicate, or assess the quality
+  of their stored learnings and decisions. This is a manual-only skill — never trigger automatically.
+allowed-tools: Read, Glob, Grep, Edit, Bash, Write, mcp__docs-mcp-server__search_docs, mcp__docs-mcp-server__list_libraries, AskUserQuestion
+---
+
+# Memory Audit Skill
+
+Audit the knowledge base in `<project>/.claude/memories/` to keep it lean, relevant, and high-quality. `<project>` refers to the current working directory. When calling `search_docs`, the library name is the root directory name of the project.
+
+Over time, memory files accumulate — some become stale, some duplicate each other, some capture generic knowledge that doesn't belong in a project-specific KB. This skill walks through every memory with the user, recommending **KEEP**, **DROP**, or **UPDATE** with clear rationale, and only acts on user-approved changes.
+
+> **This skill is user-initiated only.** Never run it automatically or as part of another workflow.
+
+---
+
+## Audit Criteria
+
+Evaluate each memory against these dimensions:
+
+### 1. Relevance
+- Does this memory apply to the **current state** of the project?
+- Has the underlying code, API, or framework changed since it was written?
+- Is this project-specific knowledge, or generic programming knowledge that any LLM already knows?
+
+### 2. Actionability
+- Can a future session **act on** this memory to avoid a mistake or follow a convention?
+- Or is it purely descriptive/documentary with no clear "do this, not that" takeaway?
+
+### 3. Naming Convention
+- Learnings must follow `learning_<topic>_<specific>.md`
+- Decisions must follow `decision_<domain>_<topic>.md`
+- Files that don't follow either pattern are likely older or ad-hoc — flag for rename or reclassification.
+
+### 4. Duplication
+- Does this memory overlap significantly with another memory?
+- Could two or more memories be merged into one stronger entry?
+- Search the existing knowledge base or memory files for semantically similar content — two memories may use different names but cover the same ground.
+
+### 5. Quality
+- Does the memory use the structured template (Problem/Solution for learnings, Context/Decision/Rationale for decisions)?
+- Is the content specific enough to be useful but general enough to be reusable?
+- Are code examples still accurate?
+
+### 6. Fact-Checking
+- **Verify key claims against the codebase.** If a memory says "we use pattern X in module Y", search the code to confirm that pattern still exists.
+- Use `Grep` to check for symbol names, type names, or patterns referenced in the memory.
+- Use `Glob` to verify that referenced files or modules still exist.
+- If a memory describes a convention (e.g., "all repositories conform to protocol X"), spot-check a few cases to confirm it holds.
+- Don't audit every single line — focus on the **central claim** of the memory. If the core assertion is wrong, recommend DROP or UPDATE.
+
+### 7. Staleness Signals
+- **Line number references** — e.g., `lines 266-296` or `FileName.swift:142`. These break after any edit. Recommend UPDATE to replace with symbol names.
+- **Deep file paths** — full nested paths like `Sources/Features/Auth/Managers/Session/SessionManager.swift` are fragile. Recommend UPDATE to use module-level references unless the path is stable and well-known.
+- **Transient details** — feature flag names being removed, in-progress PR numbers, temporary workarounds with known expiry.
+- References to features/files that may have been removed or heavily refactored.
+- Old dates without timeless content — treat as a signal for closer scrutiny, not an automatic DROP.
+
+---
+
+## Audit Workflow
+
+### Step 1: Inventory
+
+List all memory files in the project:
+
+```
+Glob(pattern: "<project>/.claude/memories/*.md")
+```
+
+If the directory is missing or empty, report the situation (specify whether it doesn't exist or is just empty) and exit — do not create the directory. If it has files, report the total count and a breakdown by category (learnings vs decisions vs non-standard naming).
+
+### Step 2: Batch Assessment
+
+Read memories in batches (5-8 at a time) and produce a verdict table for each batch:
+
+```
+| # | File | Verdict | Rationale |
+|---|------|---------|-----------|
+| 1 | learning_background_task_watchdog.md | KEEP | Project-specific debugging discovery, still relevant |
+| 2 | generic_git_workflow.md | DROP | Generic git knowledge, not project-specific |
+| 3 | decision_codestyle_naming.md | UPDATE | Convention still valid but example uses old API |
+```
+
+**Verdict definitions:**
+
+- **KEEP** — Memory is relevant, actionable, well-structured, and not duplicated. No changes needed.
+- **DROP** — Memory is stale, duplicated, generic, or no longer applicable. Recommend deletion.
+- **UPDATE** — Memory has value but needs fixes: rename to follow conventions, merge with another memory, refresh stale references, or improve structure.
+
+For UPDATE verdicts, briefly describe what needs to change.
+
+### Step 3: User Review
+
+Present each batch and wait for the user's approval before proceeding. The user may:
+- Agree with all verdicts
+- Override specific verdicts (e.g., "keep #2, I still reference it")
+- Ask for more detail on why a verdict was given
+- Ask to see the full content of a memory before deciding
+
+Respect every override — the user knows their workflow better than any heuristic.
+
+### Step 4: Execute Approved Changes
+
+After the user confirms a batch:
+
+- **DROP**: Delete the file with `Bash(rm <path>)`
+- **UPDATE (rename)**: Rename with `Bash(mv <old> <new>)`
+- **UPDATE (content)**: Use `Edit` or `Write` to update the file
+- **UPDATE (merge)**: Create the merged file, then delete the originals
+- **UPDATE (uncertain)**: If the correct replacement isn't obvious (e.g., a referenced symbol was removed and the new equivalent is unclear), ask the user what the updated content should be rather than guessing.
+
+Report what was done after each batch.
+
+### Step 5: Summary
+
+After all batches are processed, present a final summary:
+
+```
+## Audit Complete
+
+- Total memories reviewed: 42
+- KEEP: 28
+- DROP: 8
+- UPDATE: 6
+  - Renamed: 3
+  - Content updated: 2
+  - Merged: 1
+
+Knowledge base reduced from 42 → 34 files.
+```
+
+---
+
+## Guidelines
+
+- **Never delete without explicit user approval.** Always present the verdict and wait.
+- **Explain the "why" clearly.** The user should understand the reasoning behind every DROP and UPDATE recommendation, not just see the label.
+- **Be conservative with DROP.** When in doubt between KEEP and DROP, lean toward KEEP. A slightly redundant memory is better than losing hard-won knowledge.
+- **Batch size matters.** 5-8 per batch keeps the review manageable.

--- a/skills/memory-audit/SKILL.md
+++ b/skills/memory-audit/SKILL.md
@@ -33,7 +33,7 @@ Evaluate each memory against these dimensions:
 
 ### 3. Naming Convention
 - Learnings must follow `learning_<topic>_<specific>.md`
-- Decisions must follow `decision_<domain>_<topic>.md`
+- Decisions must follow `decision_<domain>_<topic>.md` — see the domain prefixes table in the [continuous-learning skill](../continuous-learning/SKILL.md) for valid domains.
 - Files that don't follow either pattern are likely older or ad-hoc — flag for rename or reclassification.
 
 ### 4. Duplication
@@ -42,7 +42,7 @@ Evaluate each memory against these dimensions:
 - Search the existing knowledge base or memory files for semantically similar content — two memories may use different names but cover the same ground.
 
 ### 5. Quality
-- Does the memory use the structured template (Problem/Solution for learnings, Context/Decision/Rationale for decisions)?
+- Does the memory follow the templates in [continuous-learning/references/templates.md](../continuous-learning/references/templates.md)? (Problem/Trigger/Solution/Verification/Example for learnings; Decision/Context/Options/Choice/Consequences for ADR decisions; Decision/Rationale/Examples for simplified decisions)
 - Is the content specific enough to be useful but general enough to be reusable?
 - Are code examples still accurate?
 

--- a/techpack.yaml
+++ b/techpack.yaml
@@ -82,6 +82,13 @@ components:
       source: skills/continuous-learning
       destination: continuous-learning
 
+  - id: skill-memory-audit
+    displayName: memory-audit skill
+    description: Reviews and audits memories to keep the knowledge base lean and valuable
+    skill:
+      source: skills/memory-audit
+      destination: memory-audit
+
   # ── Hooks ───────────────────────────────────────────────────────────────
   - id: hook-continuous-learning
     displayName: Continuous learning activator


### PR DESCRIPTION
## Summary

- **New `memory-audit` skill** — user-triggered audit that walks through all memories in batches, recommending KEEP/DROP/UPDATE with rationale. Includes fact-checking against the codebase, staleness detection, duplicate detection, and naming convention enforcement. Never deletes without explicit user approval.
- **Staleness prevention in `continuous-learning`** — new quality gate and staleness rules in templates to prevent brittle references (line numbers, deep file paths, transient state) from being saved in the first place.
- **Skill quality improvements** — filled template examples for all three memory templates, genericized all project-specific references, fixed search fallback gaps, updated retrospective mode triggers.

## Test plan

- [ ] Install pack with `mcs sync` and verify `memory-audit` skill appears
- [ ] Run "audit memories" in a project with existing memories — verify batch presentation and verdict rationale
- [ ] Create a new memory and verify staleness rules are followed (no line numbers, module-level refs)
- [ ] Run a retrospective and verify it references Step 2 search workflow