### PR TITLE
Forbid memory-filename references in shared artifacts

### DIFF
--- a/techpack.yaml
+++ b/techpack.yaml
@@ -159,8 +159,6 @@ components:
     displayName: Global gitignore
     description: Ignores memory files from version control
     gitignore:
-      - "*.local.*"
-      - ".claude/memories"
       - ".claude/.memories-last-indexed"
 
 # ---------------------------------------------------------------------------

--- a/templates/continuous-learning.md
+++ b/templates/continuous-learning.md
@@ -17,3 +17,14 @@ Search the KB again **before starting** whenever the work shifts to a new phase,
 - **New integration** — check for conventions on networking, data layer, etc.
 
 Past sessions often contain decisions and patterns that prevent unnecessary iterations and PR comments.
+
+## Referencing memories in shared artifacts
+
+Memory files are a project-internal KB — filenames drift as files are renamed or merged, and not all readers have repo access. **Never cite memory filenames** in commits, PR descriptions, issue trackers, chat, code comments, docstrings, or release notes — whether or not `.claude/memories/` is tracked in git.
+
+**Summarize the conclusion, don't paste it.** Give the reader the one sentence they need — the trigger, constraint, or choice — sized to the artifact (one line for a commit or code comment; one paragraph for a PR description). If the "why" won't fit, describe the outcome and skip it.
+
+- Bad: `See learning_orm_batch_insert_memory_spike.md`
+- Good: `Batches > 500 rows trigger an ORM memory spike — chunk in 250s.`
+
+Memory-to-memory links inside `.claude/memories/` (`Related:`, `References:`) are fine — internal graph, not an external surface.


### PR DESCRIPTION
## Context

Nothing in the pack currently tells Claude how to *refer* to memories in outputs. Left unchecked, Claude will cite memory filenames (`learning_foo.md`, `decision_bar.md`) in commits, PR descriptions, code comments, and chat — producing dangling references for readers who don't have the repo open, and rotting on the first rename or merge. The problem is independent of whether `.claude/memories/` is tracked in git: external readers (Jira watchers, Slack viewers, release-notes consumers) never have repo access, and filenames drift regardless.

Separately, the pack's own `gitignore` component disagreed with the README: `README.md:57` described memories as *"version-controlled, human-readable, editable"*, but `techpack.yaml` gitignored `.claude/memories`. Teams who wanted to commit memories had to override the pack default on every sync.

## What changed

- **`templates/continuous-learning.md`** — new top-level section *"Referencing memories in shared artifacts"* appended after the existing KB-search block. Imperative chain: **Never cite memory filenames** in commits / PRs / issue trackers / chat / code / docstrings / release notes → **Summarize the conclusion, don't paste it**, sized to the artifact (one line for a commit or code comment; one paragraph for a PR description) → escape hatch (*"if the 'why' won't fit, describe the outcome and skip it"*). Bad/Good one-liner pair mirrors the voice of the existing `Bad | Good` table in `skills/continuous-learning/SKILL.md`. Carve-out for memory-to-memory `Related:` / `References:` links inside `.claude/memories/`.
- **`techpack.yaml`** — removed `"*.local.*"` and `".claude/memories"` from the `gitignore` component. Teams now decide per-project whether to track memories; the pack-level default no longer contradicts the README.

## Design notes

- **Rule written against invariants, not defaults.** The new section's justification is *filenames drift + not all readers have repo access* — both hold whether memories are gitignored, tracked, or team-synced via a companion pack. Writing the rule this way means future changes to the tracking regime don't trigger template churn.
- **Explicit "whether or not tracked in git" clause.** Closes the most likely misread — without it, a team that commits memories would assume the rule was for the gitignored case only.
- **Terse surface list as prose, not bullets.** In a CLAUDE.local.md fragment Claude reads as persistent context, density-per-token beats visual scannability. The inline list ("commits, PR descriptions, issue trackers, chat, code comments, docstrings, or release notes") covers the realistic surfaces in one line.
- **No skill or hook changes.** The `continuous-learning` skill governs *writing* memories (capture-side); this rule governs *referencing* them from authored artifacts (output-side). Separate concerns, separate files.

## Test plan

- [ ] Re-sync via `mcs sync` in a scratch project; confirm the new section merges under `sectionIdentifier: continuous-learning` in `CLAUDE.local.md`.
- [ ] Verify `.claude/memories/` and `*.local.*` are no longer added to the synced project's gitignore by this pack.
- [ ] Start a fresh Claude Code session in the scratch project and ask: *"Draft a commit message for this change — we fixed ORM batch size based on a past learning."* Expected: the message paraphrases the reasoning; does not name any `learning_*.md` / `decision_*.md` file.
- [ ] Repeat for a PR-description ask and a code-comment ask — same expectation, sized to the artifact.
- [ ] Confirm memory-to-memory `Related:` / `References:` citations *inside* new memory files still render (carve-out intact).