### PR TITLE
Raise memory-audit batch size from 5-8 to 10-15

### DIFF
--- a/skills/memory-audit/SKILL.md
+++ b/skills/memory-audit/SKILL.md
@@ -94,7 +94,7 @@ If the directory is missing or empty, report the situation (specify whether it d
 
 ### Step 2: Batch Assessment
 
-Read memories in batches (5-8 at a time) and produce a verdict table for each batch:
+Read memories in batches (10-15 at a time) and produce a verdict table for each batch:
 
 ```
 | # | File | Verdict | Rationale |
@@ -161,4 +161,4 @@ Knowledge base reduced from 42 → 34 files.
 - **Never delete without explicit user approval.** Always present the verdict and wait.
 - **Explain the "why" clearly.** The user should understand the reasoning behind every DROP and UPDATE recommendation, not just see the label.
 - **Be conservative with DROP.** When in doubt between KEEP and DROP, lean toward KEEP. A slightly redundant memory is better than losing hard-won knowledge.
-- **Batch size matters.** 5-8 per batch keeps the review manageable.
+- **Batch size matters.** 10-15 per batch keeps the review manageable.


### PR DESCRIPTION
## Context

`memory-audit` walks every memory in batches, waits for user approval, then acts. The previous batch size of **5-8** was conservative — fine for a first pass, but for established KBs it forces more review rounds than the reviewer actually needs. Raising the floor to **10** (range 10-15) cuts the number of batches in half for typical KBs of 30-50 memories without sacrificing manageability.

## What changed

- **`skills/memory-audit/SKILL.md`** — batch-size range bumped from `5-8` to `10-15` in both places the number appears: the Step 2 workflow instruction (line 97) and the closing guidelines bullet (line 164). Kept both in lockstep so the doc doesn't drift.

## Design notes

- **Range, not just a floor.** The user asked for "at least 10"; kept the range shape from the original (upper bound caps batches at a size that still fits in working memory during review).
- **No behavior change elsewhere.** The per-batch workflow (inventory → assess → user review → execute → summary) is unchanged; only the recommended per-batch size moved.

## Test plan

- [ ] Run `/memory-audit` against a project with 20+ memories and confirm the batches presented contain 10-15 entries each.