### PR TITLE
Opt scraper into hidden-file access for memories indexing

### DIFF
--- a/hooks/sync-memories.sh
+++ b/hooks/sync-memories.sh
@@ -35,6 +35,9 @@ repo_name=$(basename "$project_root")
 
 export OPENAI_API_KEY=ollama
 export OPENAI_API_BASE=http://localhost:11434/v1
+export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_MODE=unrestricted
+export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_INCLUDE_HIDDEN=true
+export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS=true
 embedding_model="openai:nomic-embed-text"
 
 # Check if library already indexed with the same source URL

--- a/techpack.yaml
+++ b/techpack.yaml
@@ -98,9 +98,6 @@ components:
         OPENAI_API_KEY: "ollama"
         OPENAI_API_BASE: "http://localhost:11434/v1"
         DOCS_MCP_EMBEDDING_MODEL: "openai:nomic-embed-text"
-        DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_MODE: "unrestricted"
-        DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_INCLUDE_HIDDEN: "true"
-        DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS: "true"
 
   # ── Skills ──────────────────────────────────────────────────────────────
   - id: skill-continuous-learning

--- a/techpack.yaml
+++ b/techpack.yaml
@@ -98,6 +98,9 @@ components:
         OPENAI_API_KEY: "ollama"
         OPENAI_API_BASE: "http://localhost:11434/v1"
         DOCS_MCP_EMBEDDING_MODEL: "openai:nomic-embed-text"
+        DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_MODE: "unrestricted"
+        DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_INCLUDE_HIDDEN: "true"
+        DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS: "true"
 
   # ── Skills ──────────────────────────────────────────────────────────────
   - id: skill-continuous-learning


### PR DESCRIPTION
## Why

The latest `@arabold/docs-mcp-server` tightened its scraper security defaults: file access is now restricted to `$DOCUMENTS`, hidden directories are skipped, and symlinks aren't followed. Without overrides, the next upgrade silently produces an empty index for this pack — `.claude/memories/` lives under a hidden directory in arbitrary repo roots.

## Changes

Opt the scraper into unrestricted file access with `INCLUDE_HIDDEN` and `FOLLOW_SYMLINKS` enabled. Applied in two places: the MCP server's `env:` block (for consistency / future-proofing if `--read-only` is ever removed) and the sync hook's exports (the actual indexing site).

## Test plan

- Restart a session in a repo with `.claude/memories/` → `SessionStart` hook indexes without scraper errors.
- Touch a memory file mid-session, submit a prompt → "Reindexing memories..." completes cleanly.
- `npx -y @arabold/docs-mcp-server@latest list` shows the library with `sourceUrl: file:///…/.claude/memories` and non-zero version count.