### PR TITLE
Nudge KB search when debugging mid-session

### DIFF
--- a/hooks/continuous-learning-activator.sh
+++ b/hooks/continuous-learning-activator.sh
@@ -6,6 +6,9 @@ MANDATORY MEMORY PROTOCOL
 If this starts a new sub-task or phase (tests, refactor, deploy, etc.)
 → search the KB via search_docs for relevant patterns first.
 
+If you hit an unexpected error or are about to debug/diagnose
+→ search the KB FIRST, before reasoning from scratch.
+
 If this request produced reusable knowledge worth preserving, invoke
 Skill(continuous-learning) — the skill evaluates and routes the knowledge
 to the correct destination (.claude/memories/ for codebase knowledge,

--- a/templates/continuous-learning.md
+++ b/templates/continuous-learning.md
@@ -10,9 +10,10 @@ Only after completing these steps should you proceed with discovery and implemen
 ### When to re-check mid-session
 
 Search the KB again **before starting** whenever the work shifts to a new phase, including but not limited to:
+- **Debugging an unexpected failure** — search by topic/domain, not the literal error message; code you can't directly read (generated mocks, codegen output) is the highest-value case to check.
 - **Writing or updating tests** — check for testing conventions, patterns, preferred frameworks
 - **Refactoring** — check for architectural decisions and code style preferences
-- **Error handling / validation** — check for established patterns
+- **Error-handling code / validation** — check for established patterns
 - **CI/CD or deployment** — check for workflow decisions
 - **New integration** — check for conventions on networking, data layer, etc.
 


### PR DESCRIPTION
## Why

The memory system prompts a knowledge-base check at task start and at phase boundaries, but a failure that surfaces mid-task (a compile error, a failing test) isn't a phase boundary — so documented gotchas got rediscovered from scratch instead of recalled. This adds debugging as an explicit moment to consult memory, and steers the search toward the topic rather than the literal error message, since the relevant memory is usually keyed on the domain (e.g. generated/invisible code) and not the error string.

## Test plan

- Run `hooks/continuous-learning-activator.sh` → expect the output to include the new "hit an unexpected error or are about to debug/diagnose → search the KB FIRST" clause.