### PR TITLE
Fall back to launch dir when resolving project root outside git

### DIFF
--- a/hooks/sync-memories.sh
+++ b/hooks/sync-memories.sh
@@ -8,7 +8,12 @@ set -uo pipefail
 # Consume stdin (hook passes JSON context)
 cat >/dev/null 2>&1 || true
 
-project_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+# Resolve the project root. Prefer the git repo toplevel — it's the stable
+# anchor so launching from any subdirectory of a repo maps to the same library.
+# In a non-git folder git exits non-zero (empty output); fall back to where
+# Claude was launched (CLAUDE_PROJECT_DIR, else $PWD).
+project_root=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -n "$project_root" ] || project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
 
 MEMORIES_DIR="$project_root/.claude/memories"
 TIMESTAMP_FILE="$project_root/.claude/.memories-last-indexed"


### PR DESCRIPTION
## Why

The sync-memories hook resolved the project root exclusively through `git rev-parse --show-toplevel` and bailed silently (`|| exit 0`) when it failed. In a non-git folder this meant memories were never indexed, with no visible error.

PR #11 fixed this same bug but was reverted in #12 for bundling too much unrelated hardening (diagnostic logging, doc-count verification, embedding env var, scrape/refresh rework) into one change. This PR extracts just the non-git fallback, nothing else.

## Change

`hooks/sync-memories.sh`: when `git rev-parse` yields nothing, fall back to `CLAUDE_PROJECT_DIR`, then `$PWD`. Git-repo resolution (anchoring to the toplevel) is unchanged.

## Test plan

- [x] `bash -n` syntax check
- [x] From a non-git scratch dir with `.claude/memories/*.md`, ran the hook directly — it resolved `project_root` to the scratch dir, indexed it into docs-mcp-server (confirmed via `list`), and wrote `.memories-last-indexed`
- [x] Non-git dir with no `.claude/memories` — hook exits 0, no side effects
- [x] From a subdirectory of this git repo, hook still resolves to the repo toplevel (unchanged)