### PR TITLE
Install docs-mcp-server ahead of launch to fix -32000 failures

### DIFF
--- a/hooks/sync-memories.sh
+++ b/hooks/sync-memories.sh
@@ -43,20 +43,18 @@ export OPENAI_API_BASE=http://localhost:11434/v1
 export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_MODE=unrestricted
 export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_INCLUDE_HIDDEN=true
 export DOCS_MCP_SCRAPER_SECURITY_FILE_ACCESS_FOLLOW_SYMLINKS=true
-embedding_model="openai:nomic-embed-text"
+export DOCS_MCP_EMBEDDING_MODEL="openai:nomic-embed-text"
 
 # Check if library already indexed with the same source URL
-existing_url=$(npx -y @arabold/docs-mcp-server@latest list 2>/dev/null \
+existing_url=$(docs-mcp-server list 2>/dev/null \
     | jq -r --arg name "$repo_name" '.[] | select(.name == $name) | .versions[0].sourceUrl // empty')
 
 if [ "$existing_url" = "file://$MEMORIES_DIR" ]; then
-    npx -y @arabold/docs-mcp-server@latest refresh "$repo_name" \
-        --embedding-model "$embedding_model" \
+    docs-mcp-server refresh "$repo_name" \
         --silent >/dev/null 2>&1
 else
-    npx -y @arabold/docs-mcp-server@latest scrape "$repo_name" \
+    docs-mcp-server scrape "$repo_name" \
         "file://$MEMORIES_DIR" \
-        --embedding-model "$embedding_model" \
         --silent >/dev/null 2>&1
 fi
 

--- a/techpack.yaml
+++ b/techpack.yaml
@@ -83,15 +83,32 @@ components:
           - "http://localhost:11434/v1/embeddings"
 
   # ── MCP Servers ─────────────────────────────────────────────────────────
+  # Install the binary once (pinned) so Claude launches a prebuilt binary.
+  # `npx @latest` re-downloaded on every cache eviction, blowing Claude's 30s
+  # MCP startup limit → "MCP error -32000: Connection closed".
+  - id: docs-mcp-server-install
+    displayName: docs-mcp-server binary
+    description: Installs the docs-mcp-server MCP binary once so Claude launches a prebuilt binary
+    dependencies: [node]
+    type: configuration
+    shell: "npm install -g @arabold/docs-mcp-server@2.4.2"
+    doctorChecks:
+      # `list` loads the better-sqlite3 native addon (a broken/ABI-mismatched
+      # build fails here); `--version` wouldn't — it never loads it.
+      - type: commandExists
+        name: "docs-mcp-server binary loads"
+        section: MCP Servers
+        command: docs-mcp-server
+        args: ["list"]
+        fixCommand: "npm install -g @arabold/docs-mcp-server@2.4.2"
+
   - id: docs-mcp-server
     description: Semantic search over memories using local Ollama embeddings
     isRequired: true
-    dependencies: [node, ollama]
+    dependencies: [node, ollama, docs-mcp-server-install]
     mcp:
-      command: npx
+      command: docs-mcp-server
       args:
-        - "-y"
-        - "@arabold/docs-mcp-server@latest"
         - "--read-only"
         - "--telemetry=false"
       env:


### PR DESCRIPTION
## Why

Users install the pack, run `mcs sync`, see `mcs doctor` all green — then Claude fails to connect to docs-mcp-server with `MCP error -32000: Connection closed` (a `/mcp` reconnect usually, but not always, recovered it). The server was launched via `npx …@latest`, which re-downloads the package and its native modules whenever the npx cache is evicted; that cold start routinely exceeds Claude's 30-second MCP startup budget and the connection is torn down.

The pack now installs a pinned server version once during sync, so Claude launches an already-built binary that connects in a few seconds. A doctor check runs the binary in a way that loads its native module, so a missing or ABI-broken build surfaces as a failure instead of a silent -32000 later.

## Test plan

1. Run `mcs sync` in a memory-enabled project → the docs-mcp-server binary installs and `mcs doctor` shows "docs-mcp-server binary loads" green.
2. Wipe the npx cache (`rm -rf ~/.npm/_npx/*`) and open `claude` in that project → docs-mcp-server connects with no `-32000`; the newest `~/Library/Caches/claude-cli-nodejs/<project>/mcp-logs-docs-mcp-server/*.jsonl` shows a low-seconds connect.
3. In the session, call `search_docs` → returns indexed memory results.