### PR TITLE
Say what ignore: actually does

### DIFF
--- a/techpack.yaml
+++ b/techpack.yaml
@@ -271,7 +271,8 @@ components:
       - ".claude/.kb-gate.log"
 
 # ---------------------------------------------------------------------------
-# Ignore — maintainer-only files not shipped with the pack
+# Ignore — suppress update notifications for changes to maintainer-only files.
+# Does not affect what installs; that is decided by the components above.
 # ---------------------------------------------------------------------------
 ignore:
   - CLAUDE.md


### PR DESCRIPTION
## Why

The comment above `ignore:` described it as listing files "not shipped with the pack". That is not what the field does. Installation is decided by what the components reference; `ignore:` suppresses update notifications for changes to the files it lists, so editing a maintainer-only doc doesn't prompt every user to update.

The distinction matters because the wrong reading is the dangerous one: someone could add a file to `ignore:` expecting it to stay out of an install, and it would ship anyway. That mistake was made earlier today, believing the comment over the behavior.

## Test plan

Nothing to verify at runtime, this is a comment. `mcs pack validate` should still accept the manifest.