### PR TITLE
Repaint the loop diagrams from the deck palette and tighten the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # The Memory Loop
 
-### Claude Code that learns your codebase, session after session.
+### Project knowledge that outlives the session.
 
 [![MCS tech pack](https://img.shields.io/badge/MCS-tech%20pack-6f42c1)](https://github.com/mcs-cli/mcs)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-compatible-d97757)](https://docs.anthropic.com/en/docs/claude-code)
@@ -13,12 +13,17 @@
 
 **The Memory Loop** gives Claude Code persistent, project-specific memory. It captures debugging discoveries, architectural decisions, and local conventions in a searchable knowledge base—then brings the right context back into future sessions. Instead of rediscovering the same lessons, Claude gets increasingly effective at working in *your* codebase.
 
-> The project was formerly called **Memory**, and originally **Continuous Learning**. Its repository, package coordinate, and internal identifiers remain unchanged for compatibility.
-
 ```text
 identifier: memory
 requires:   mcs >= 2026.4.12
 ```
+
+<details>
+<summary>Why the identifier says <code>memory</code></summary>
+
+The project was formerly called **Memory**, and originally **Continuous Learning**. Its repository, pack name, and internal identifiers are unchanged, so existing installs keep working and `mcs pack add mcs-cli/memory` remains the way to add it.
+
+</details>
 
 ## Install
 
@@ -29,11 +34,13 @@ mcs sync --global                 # 3. install globally (~/.claude)
 mcs doctor                        # 4. verify everything is healthy
 ```
 
-**Prerequisites:** macOS, [Claude Code](https://docs.anthropic.com/en/docs/claude-code), and Node 22 or newer. `mcs` installs the remaining dependencies (`gh`, `jq`, and [qmd](https://github.com/tobi/qmd)) automatically. The first sync also downloads a shared ~610 MB embedding model. Everything runs locally, with no daemon left running between sessions.
+**Prerequisites:** macOS, [Claude Code](https://docs.anthropic.com/en/docs/claude-code), and Node.js 22 or newer (the current qmd requirement). `mcs` installs the remaining dependencies (`gh`, `jq`, and [qmd](https://github.com/tobi/qmd)) automatically. The first sync also downloads a shared ~610 MB embedding model. Everything runs locally, with no daemon left running between sessions.
 
 Global installation is recommended because the pack has no per-project configuration. Install it once and memory becomes available in every project. To scope it to a single repository instead, run `mcs sync` from inside that repository.
 
 ## How the loop works
+
+**There are no commands to remember.** Once installed, the loop runs automatically. Semantic search retrieves memories only when relevant, so the knowledge base does not unnecessarily consume context.
 
 <p align="center">
   <picture>
@@ -60,7 +67,31 @@ Memories are version-controlled, human-readable Markdown in two formats:
 | **Learnings** | Non-obvious discoveries from debugging, such as `learning_orm_batch_insert_memory_spike.md` | *Problem → Trigger Conditions → Solution → Verification → Example → Notes* |
 | **Decisions** | Deliberate architecture or convention choices, such as `decision_testing_snapshot_strategy.md` | *Decision → Context → Options Considered → Choice → Consequences* |
 
-The `memory-audit` skill reviews the collection over time, flagging stale or duplicate entries so the knowledge base stays useful rather than merely growing.
+A learning ends up looking like this—the verdict, not the transcript that produced it:
+
+```markdown
+# Learning: Batch inserts above 500 rows spike memory
+
+**Applies to:** billing-service
+
+## Problem
+The bulk importer holds an entire batch in memory before flushing, so a
+5,000-row import peaks near 2 GB and the worker is OOM-killed.
+
+## Trigger Conditions
+- Any single batch-insert call above ~500 rows
+- Only in the import worker; the request path never batches this large
+
+## Solution
+Chunk at 250 rows and flush between chunks.
+
+## Verification
+The same 5,000-row import peaks at 180 MB.
+```
+
+The next session that touches the importer finds this in one search, instead of reproducing the OOM to learn it again.
+
+The `memory-audit` skill reviews the collection, flagging stale or duplicate entries so the knowledge base stays useful rather than merely growing. It is the one part of the pack that never runs on its own—ask for it (*"audit memories"*) when the collection needs a review.
 
 ## Gate modes
 

--- a/assets/the-memory-loop-dark.svg
+++ b/assets/the-memory-loop-dark.svg
@@ -3,20 +3,16 @@
   <desc id="desc">Sessions search existing knowledge, follow the usual workflow, save valuable conclusions, and re-index them for the next session.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M1 1l10 5-10 5z" fill="#aab4c4"/>
+      <path d="M1 1l10 5-10 5z" fill="#F1F0F8"/>
     </marker>
-    <filter id="violetGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#9b87f5" flood-opacity=".24"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="blueGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#60a5fa" flood-opacity=".22"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="mintGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#6ee7b7" flood-opacity=".22"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="amberGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#f6c760" flood-opacity=".22"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <style>
-      .flow{fill:none;stroke:#aab4c4;stroke-width:4;marker-end:url(#arrow)}
+      .flow{fill:none;stroke:#F1F0F8;stroke-width:4;marker-end:url(#arrow);opacity:.55}
       .dash{stroke-dasharray:12 10}
-      .card{fill:#111827;stroke-width:4}
-      .heading{fill:#f9fafb;font:700 31px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;text-anchor:middle}
-      .sub{fill:#d0d5dd;font:24px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
-      .label{fill:#c8d0dc;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle;letter-spacing:.5px}
-      .center{fill:#c8d0dc;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
+      .card{fill:#1B1A2A;stroke-width:4}
+      .heading{fill:#F1F0F8;font:600 28px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;text-anchor:middle}
+      .sub{fill:#F1F0F8;fill-opacity:.65;font:24px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
+      .label{fill:#F1F0F8;fill-opacity:.8;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle;letter-spacing:.5px}
+      .center{fill:#F1F0F8;fill-opacity:.8;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
     </style>
   </defs>
 
@@ -29,32 +25,32 @@
   <text class="label" x="1305" y="783">STARTS INFORMED</text>
   <text class="label" x="238" y="783">SESSION ENDS</text>
 
-  <path class="flow dash" d="M460 487h190"/>
-  <path class="flow dash" d="M866 487h190"/>
-  <text class="label" x="550" y="459">WRITES</text>
-  <text class="label" x="963" y="459">READS</text>
-  <rect x="660" y="430" width="206" height="124" rx="22" fill="none" stroke="#aab4c4" stroke-width="3" stroke-dasharray="12 9"/>
-  <text class="center" x="763" y="482">INDEXED</text>
-  <text class="center" x="763" y="516">LOCALLY</text>
+  <path class="flow dash" d="M475 491h170"/>
+  <path class="flow dash" d="M881 491h167"/>
+  <text class="label" x="560" y="463">WRITES</text>
+  <text class="label" x="964" y="463">READS</text>
+  <rect x="660" y="429" width="206" height="124" rx="22" fill="none" stroke="#F1F0F8" stroke-opacity=".5" stroke-width="3" stroke-dasharray="12 9"/>
+  <text class="center" x="763" y="479">INDEXED</text>
+  <text class="center" x="763" y="513">LOCALLY</text>
 
-  <g filter="url(#violetGlow)">
-    <rect class="card" x="536" y="75" width="460" height="172" rx="25" stroke="#9b87f5"/>
-    <text class="heading" x="766" y="153">SESSION STARTS</text>
-    <text class="sub" x="766" y="201">Hook re-indexes the KB</text>
+  <g>
+    <rect class="card" x="536" y="69" width="460" height="184" rx="25" stroke="#AB95FF"/>
+    <text class="heading" x="766" y="145">SESSION STARTS</text>
+    <text class="sub" x="766" y="192">Hook re-indexes the KB</text>
   </g>
-  <g filter="url(#blueGlow)">
-    <rect class="card" x="1063" y="399" width="423" height="184" rx="25" stroke="#60a5fa"/>
-    <text class="heading" x="1274" y="481">SEARCH WHAT'S KNOWN</text>
-    <text class="sub" x="1274" y="528">Before reading any file</text>
+  <g>
+    <rect class="card" x="1063" y="399" width="423" height="184" rx="25" stroke="#86B4F7"/>
+    <text class="heading" x="1274" y="475">SEARCH WHAT'S KNOWN</text>
+    <text class="sub" x="1274" y="522">Before reading any file</text>
   </g>
-  <g filter="url(#mintGlow)">
-    <rect class="card" x="547" y="766" width="442" height="172" rx="25" stroke="#6ee7b7"/>
-    <text class="heading" x="768" y="844">WORK</text>
-    <text class="sub" x="768" y="892">Workflow unchanged</text>
+  <g>
+    <rect class="card" x="547" y="760" width="442" height="184" rx="25" stroke="#62CE9C"/>
+    <text class="heading" x="768" y="836">WORK</text>
+    <text class="sub" x="768" y="883">Workflow unchanged</text>
   </g>
-  <g filter="url(#amberGlow)">
-    <rect class="card" x="53" y="399" width="407" height="184" rx="25" stroke="#f6c760"/>
-    <text class="heading" x="256" y="481">KEEP THE VERDICT</text>
-    <text class="sub" x="256" y="528">Save only what matters</text>
+  <g>
+    <rect class="card" x="53" y="399" width="407" height="184" rx="25" stroke="#E5B264"/>
+    <text class="heading" x="256" y="475">KEEP THE VERDICT</text>
+    <text class="sub" x="256" y="522">Save only what matters</text>
   </g>
 </svg>

--- a/assets/the-memory-loop-light.svg
+++ b/assets/the-memory-loop-light.svg
@@ -3,20 +3,16 @@
   <desc id="desc">Sessions search existing knowledge, follow the usual workflow, save valuable conclusions, and re-index them for the next session.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 12 12" refX="10" refY="6" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M1 1l10 5-10 5z" fill="#344054"/>
+      <path d="M1 1l10 5-10 5z" fill="#17161F"/>
     </marker>
-    <filter id="violetGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#8b5cf6" flood-opacity=".2"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="blueGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#3b82f6" flood-opacity=".18"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="mintGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#34d399" flood-opacity=".18"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="amberGlow" x="-30%" y="-50%" width="160%" height="200%"><feGaussianBlur stdDeviation="13" result="b"/><feFlood flood-color="#fbbf24" flood-opacity=".18"/><feComposite in2="b" operator="in"/><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     <style>
-      .flow{fill:none;stroke:#344054;stroke-width:4;marker-end:url(#arrow)}
+      .flow{fill:none;stroke:#17161F;stroke-width:4;marker-end:url(#arrow);opacity:.55}
       .dash{stroke-dasharray:12 10}
-      .card{fill:#111827;stroke-width:4}
-      .heading{fill:#f9fafb;font:700 31px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;text-anchor:middle}
-      .sub{fill:#d0d5dd;font:24px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
-      .label{fill:#344054;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle;letter-spacing:.5px}
-      .center{fill:#344054;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
+      .card{fill:#FFFFFF;stroke-width:4}
+      .heading{fill:#17161F;font:600 28px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;text-anchor:middle}
+      .sub{fill:#17161F;fill-opacity:.65;font:24px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
+      .label{fill:#17161F;fill-opacity:.8;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle;letter-spacing:.5px}
+      .center{fill:#17161F;fill-opacity:.8;font:22px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-anchor:middle}
     </style>
   </defs>
 
@@ -29,32 +25,32 @@
   <text class="label" x="1305" y="783">STARTS INFORMED</text>
   <text class="label" x="238" y="783">SESSION ENDS</text>
 
-  <path class="flow dash" d="M460 487h190"/>
-  <path class="flow dash" d="M866 487h190"/>
-  <text class="label" x="550" y="459">WRITES</text>
-  <text class="label" x="963" y="459">READS</text>
-  <rect x="660" y="430" width="206" height="124" rx="22" fill="none" stroke="#667085" stroke-width="3" stroke-dasharray="12 9"/>
-  <text class="center" x="763" y="482">INDEXED</text>
-  <text class="center" x="763" y="516">LOCALLY</text>
+  <path class="flow dash" d="M475 491h170"/>
+  <path class="flow dash" d="M881 491h167"/>
+  <text class="label" x="560" y="463">WRITES</text>
+  <text class="label" x="964" y="463">READS</text>
+  <rect x="660" y="429" width="206" height="124" rx="22" fill="none" stroke="#17161F" stroke-opacity=".5" stroke-width="3" stroke-dasharray="12 9"/>
+  <text class="center" x="763" y="479">INDEXED</text>
+  <text class="center" x="763" y="513">LOCALLY</text>
 
-  <g filter="url(#violetGlow)">
-    <rect class="card" x="536" y="75" width="460" height="172" rx="25" stroke="#8b5cf6"/>
-    <text class="heading" x="766" y="153">SESSION STARTS</text>
-    <text class="sub" x="766" y="201">Hook re-indexes the KB</text>
+  <g>
+    <rect class="card" x="536" y="69" width="460" height="184" rx="25" stroke="#6C4CF0"/>
+    <text class="heading" x="766" y="145">SESSION STARTS</text>
+    <text class="sub" x="766" y="192">Hook re-indexes the KB</text>
   </g>
-  <g filter="url(#blueGlow)">
-    <rect class="card" x="1063" y="399" width="423" height="184" rx="25" stroke="#3b82f6"/>
-    <text class="heading" x="1274" y="481">SEARCH WHAT'S KNOWN</text>
-    <text class="sub" x="1274" y="528">Before reading any file</text>
+  <g>
+    <rect class="card" x="1063" y="399" width="423" height="184" rx="25" stroke="#1F63C4"/>
+    <text class="heading" x="1274" y="475">SEARCH WHAT'S KNOWN</text>
+    <text class="sub" x="1274" y="522">Before reading any file</text>
   </g>
-  <g filter="url(#mintGlow)">
-    <rect class="card" x="547" y="766" width="442" height="172" rx="25" stroke="#34d399"/>
-    <text class="heading" x="768" y="844">WORK</text>
-    <text class="sub" x="768" y="892">Workflow unchanged</text>
+  <g>
+    <rect class="card" x="547" y="760" width="442" height="184" rx="25" stroke="#177C52"/>
+    <text class="heading" x="768" y="836">WORK</text>
+    <text class="sub" x="768" y="883">Workflow unchanged</text>
   </g>
-  <g filter="url(#amberGlow)">
-    <rect class="card" x="53" y="399" width="407" height="184" rx="25" stroke="#f5b942"/>
-    <text class="heading" x="256" y="481">KEEP THE VERDICT</text>
-    <text class="sub" x="256" y="528">Save only what matters</text>
+  <g>
+    <rect class="card" x="53" y="399" width="407" height="184" rx="25" stroke="#A9660C"/>
+    <text class="heading" x="256" y="475">KEEP THE VERDICT</text>
+    <text class="sub" x="256" y="522">Save only what matters</text>
   </g>
 </svg>


### PR DESCRIPTION
## Why

The diagram text rendered blurry on GitHub. Each card sat inside a glow effect, and a glow forces everything underneath it — the card titles included — through a bitmap, which is then scaled down to the width the README displays. Dropping the glow makes the text vector again.

With the colours being touched anyway, they now come from the talk deck's theme tokens instead of a set borrowed from dark backgrounds. That fixes a second problem: the "light" diagram was showing dark cards on a white page, and the dark one barely separated from the page behind it. Card sizes and the writes/reads connector were also inconsistent enough to notice once the glow stopped hiding them.

Separately, the README described the memory audit as something that reviews the collection over time, which reads as automatic. It is manual by design, so it now says so and gives the phrase that triggers it. The tagline and a worked example of a saved learning came out of the same pass.

## Test plan

- View the README on GitHub with the system appearance set to light, then dark → card titles render sharp rather than soft, and in both cases the cards read clearly against the page.
- Confirm the two diagram files still differ only in colour — they share all their geometry and nothing enforces that:
  ```bash
  diff <(sed 's/#[0-9a-fA-F]\{6\}/C/g' assets/the-memory-loop-light.svg) \
       <(sed 's/#[0-9a-fA-F]\{6\}/C/g' assets/the-memory-loop-dark.svg)
  ```
  → expect no output.

https://claude.ai/code/session_01BDQxQwWQPFeufRRa7Sj2BJ